### PR TITLE
Fix string mutation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,35 +56,34 @@ fn main() {
     ];
     let current_word = words.choose(&mut rand::thread_rng()).unwrap();
     let mut states_ind = 0;
-    let mut s;
+    let mut current_guess;
     let mut guessed = HashSet::<char>::new();
     let mut current_word_set = HashSet::new();
     for c in current_word.chars() {
         current_word_set.insert(c);
     }
-    let mut current_state = vec!["_"; (*current_word).len()];
+    let mut partially_revealed = "_".repeat(current_word.len());
     while states_ind != states.len() - 1 {
-        s = String::new();
+        current_guess = String::new();
         println!("{}", states[states_ind]);
-        println!("{}", current_state.iter().map({|c| format!("{} ", c)}).collect::<String>());
+        println!("{}", partially_revealed);
         println!("Make a guess!");
         print!("> ");
         io::stdout().flush().unwrap();
-        stdin().read_line(&mut s).unwrap();
-        let c = s.chars().next().unwrap();
+        stdin().read_line(&mut current_guess).unwrap();
+        let c = current_guess.chars().next().unwrap();
         if guessed.contains(&c) {
             println!("You already guessed that!");
             continue;
         }
-        if ! current_word_set.contains(&c) {
+        if !current_word_set.contains(&c) {
             current_word_set.insert(c);
             states_ind += 1;
             println!("Incorrect");
         } else {
-            for (i, val) in current_word.chars().enumerate() {
-                if c == val{
-                    current_state[i] = &format!("{}", val.to_string());
-                }
+            for (i, chr) in current_word.char_indices().filter(|(_, chr)| c == *chr) {
+                let chr_string: String = chr.to_string();
+                partially_revealed.replace_range(i..i + chr_string.len(), &chr_string);
             }
         }
         guessed.insert(c);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,58 +1,63 @@
-use std::io::{self, Write};
-use std::io::stdin;
 use rand::seq::SliceRandom;
 use std::collections::HashSet;
+use std::io::stdin;
+use std::io::{self, Write};
+
 fn main() {
-    let words = vec!["snakes", "thanks", "granted", "awkward", "bagpipes", "banjo", "bungler", "croquet", "crypt"];
-    let states  = [r#"
+    let words = vec![
+        "snakes", "thanks", "granted", "awkward", "bagpipes", "banjo", "bungler", "croquet",
+        "crypt",
+    ];
+    let states = [
+        r#"
 |-----|
 |
 |
 |
 |_______
     "#,
-    r#"
+        r#"
 |-----|
 |     o
 |
 |
 |_______
     "#,
-    r#"
+        r#"
 |-----|
 |     o
 |     |
 |
 |_______
     "#,
-    r#"
+        r#"
 |-----|
 |     o
 |     |
 |    /
 |_______
     "#,
-    r#"
+        r#"
 |-----|
 |     o
 |     |
 |    / \
 |_______
     "#,
-    r#"
+        r#"
 |-----|
 |     o
 |    /|
 |    / \
 |_______
     "#,
-    r#"
+        r#"
 |-----|
 |     o
 |    /|\
 |    / \
 |_______
-    "#
+    "#,
     ];
     let current_word = words.choose(&mut rand::thread_rng()).unwrap();
     let mut states_ind = 0;


### PR DESCRIPTION
# Use `.char_indices` and `.replace_range`

- Make `current_state` a String.
- Rather than `.chars().enumerate()`, use `.char_indices()`, which gives *byte offsets* into the str rather than the index of a particular `char` value.
    - strs are UTF-8-encoded, so byte offsets and character indices are
      not interchangeable.

- Use `String::replace_range` rather than assigning to an index; this sort of makes sense, but sorta doesn't. Anyways, it works.
    - The ergonomics on replacing a range within a String are less-than-ideal, unfortunately (it's not particularly intuitive that `String::replace_range` is the method one wants).

- Renamed `s` -> `current_guess`
- Renamed `current_state` -> `partially_revealed`
- Renamed `val` -> `chr`
- Reformatted code with `cargo fmt`

Glad to see you writing some Rust! 😄